### PR TITLE
Fix CIS Levels

### DIFF
--- a/inspec-gke-cis-gcp/controls/5.01-container-registry.rb
+++ b/inspec-gke-cis-gcp/controls/5.01-container-registry.rb
@@ -195,7 +195,7 @@ control "cis-gke-#{sub_control_id}-#{control_abbrev}" do
   See also Recommendation 6.10.5."
 
   tag cis_scored: false
-  tag cis_level: 1
+  tag cis_level: 2
   tag cis_gke: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s

--- a/inspec-gke-cis-gcp/controls/5.04-node-metadata.rb
+++ b/inspec-gke-cis-gcp/controls/5.04-node-metadata.rb
@@ -93,7 +93,7 @@ else
     underlying metadata server."
 
     tag cis_scored: true
-    tag cis_level: 1
+    tag cis_level: 2
     tag cis_gke: sub_control_id.to_s
     tag cis_version: cis_version.to_s
     tag project: gcp_project_id.to_s

--- a/inspec-gke-cis-gcp/controls/5.05-nodes.rb
+++ b/inspec-gke-cis-gcp/controls/5.05-nodes.rb
@@ -50,7 +50,7 @@ else
   - Locked-down by default: COS instances include a locked-down firewall and other security settings by default."
 
     tag cis_scored: true
-    tag cis_level: 1
+    tag cis_level: 2
     tag cis_gke: sub_control_id.to_s
     tag cis_version: cis_version.to_s
     tag project: gcp_project_id.to_s
@@ -252,7 +252,7 @@ else
     process if signature verification fails."
 
     tag cis_scored: true
-    tag cis_level: 1
+    tag cis_level: 2
     tag cis_gke: sub_control_id.to_s
     tag cis_version: cis_version.to_s
     tag project: gcp_project_id.to_s

--- a/inspec-gke-cis-gcp/controls/5.06-networking.rb
+++ b/inspec-gke-cis-gcp/controls/5.06-networking.rb
@@ -47,7 +47,7 @@ else
     intranode traffic."
 
     tag cis_scored: true
-    tag cis_level: 1
+    tag cis_level: 2
     tag cis_gke: sub_control_id.to_s
     tag cis_version: cis_version.to_s
     tag project: gcp_project_id.to_s
@@ -145,7 +145,7 @@ else
   Although Kubernetes API requires an authorized token to perform sensitive actions, a vulnerability could potentially expose the Kubernetes publically with unrestricted access. Additionally, an attacker may be able to identify the current cluster and Kubernetes API version and determine whether it is vulnerable to an attack. Unless required, disabling public endpoint will help prevent such threats, and require the attacker to be on the master's VPC network to perform any attack on the Kubernetes API."
 
     tag cis_scored: true
-    tag cis_level: 1
+    tag cis_level: 2
     tag cis_gke: sub_control_id.to_s
     tag cis_version: cis_version.to_s
     tag project: gcp_project_id.to_s

--- a/inspec-gke-cis-gcp/controls/5.10-other.rb
+++ b/inspec-gke-cis-gcp/controls/5.10-other.rb
@@ -137,7 +137,7 @@ else
     enforcing validation, you can gain tighter control over your container environment by ensuring only verified images are integrated into the build-and-release process."
 
     tag cis_scored: true
-    tag cis_level: 1
+    tag cis_level: 2
     tag cis_gke: sub_control_id.to_s
     tag cis_version: cis_version.to_s
     tag project: gcp_project_id.to_s

--- a/inspec-gke-cis-k8s/controls/4.02-pod-security-policies.rb
+++ b/inspec-gke-cis-k8s/controls/4.02-pod-security-policies.rb
@@ -274,7 +274,7 @@ control "cis-gke-#{sub_control_id}-#{control_abbrev}" do
   given permission to access that PSP."
 
   tag cis_scored: true
-  tag cis_level: 1
+  tag cis_level: 2
   tag cis_gke: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s
@@ -428,7 +428,7 @@ control "cis-gke-#{sub_control_id}-#{control_abbrev}" do
   minimized."
 
   tag cis_scored: false
-  tag cis_level: 1
+  tag cis_level: 2
   tag cis_gke: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s

--- a/inspec-gke-cis-k8s/controls/4.03-network-policies-and-cni.rb
+++ b/inspec-gke-cis-k8s/controls/4.03-network-policies-and-cni.rb
@@ -37,7 +37,7 @@ control "cis-gke-#{sub_control_id}-#{control_abbrev}" do
   users are given permission to access that PSP."
 
   tag cis_scored: true
-  tag cis_level: 1
+  tag cis_level: 2
   tag cis_gke: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s

--- a/inspec-gke-cis-ssh/controls/3.02-kubelet.rb
+++ b/inspec-gke-cis-ssh/controls/3.02-kubelet.rb
@@ -280,7 +280,7 @@ control "cis-gke-#{sub_control_id}-#{control_abbrev}" do
   consistently monitored using the event data."
 
   tag cis_scored: true
-  tag cis_level: 1
+  tag cis_level: 2
   tag cis_gke: sub_control_id.to_s
   tag cis_version: cis_version.to_s
   tag project: gcp_project_id.to_s


### PR DESCRIPTION
Some controls have incorrectly labeled CIS Level. This PR fixes those, based on the manual spot-check against the CIS GKE 1.1.0 reference doc.

The reason our team cares about their correctness is because we prioritize our compliance implementation decisions based on whether a certain control is Level 1 (required) or Level 2 (recommended).

Thank you!